### PR TITLE
Fix bug in `.settings()`

### DIFF
--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -826,9 +826,16 @@ class ClickHouseQueryBuilder(QueryBuilder):
             clauses.append(f"SAMPLE {self._sample}")
         if self._sample_offset is not None:
             clauses.append(f"OFFSET {self._sample_offset}")
-        if self._settings:
-            clauses.append(f"SETTINGS {', '.join(f'{k}={v}' for k, v in sorted(self._settings.items()))}")
         return " FROM {clauses}".format(clauses=" ".join(clauses))
+
+    def _apply_pagination(self, querystring: str) -> str:
+        # For SELECTs, SETTINGS must come after LIMIT, which is added by _apply_pagination:
+        querystring = super()._apply_pagination(querystring)
+
+        if self._settings:
+            querystring += f" SETTINGS {', '.join(f'{k}={v}' for k, v in sorted(self._settings.items()))}"
+
+        return querystring
 
     def _set_sql(self, **kwargs: Any) -> str:
         return " UPDATE {set}".format(

--- a/pypika/tests/dialects/test_clickhouse.py
+++ b/pypika/tests/dialects/test_clickhouse.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+import pypika.terms
 from pypika import (
     ClickHouseQuery,
     Database,
@@ -25,12 +26,12 @@ class ClickHouseQueryTests(TestCase):
 
     def test_settings(self) -> None:
         t = Table('abc')
-        query1 = ClickHouseQuery.from_(t).select(t.foo).settings(foo="bar")
+        query1 = ClickHouseQuery.from_(t).select(t.foo).settings(foo="bar").limit(1)
         query2 = query1.settings(baz="qux")
         # Settings get deep-copied:
-        self.assertEqual(str(query1), 'SELECT "foo" FROM "abc" SETTINGS foo=bar')
+        self.assertEqual(str(query1), 'SELECT "foo" FROM "abc" LIMIT 1 SETTINGS foo=bar')
         # Settings are ordered alphabetically in the query string:
-        self.assertEqual(str(query2), 'SELECT "foo" FROM "abc" SETTINGS baz=qux, foo=bar')
+        self.assertEqual(str(query2), 'SELECT "foo" FROM "abc" LIMIT 1 SETTINGS baz=qux, foo=bar')
 
 class ClickHouseDeleteTests(TestCase):
     table_abc = Table("abc")


### PR DESCRIPTION
### Summary

Clickhouse SQL has an optional [`SETTINGS` clause](settings-clause) with
`SELECT`s which can be used to configure [all kinds of options](settings).

In #1, I took a stab at implementing this, but the implementation contained a bug:
the `SETTINGS` need to be added after `LIMIT`, not directly after the `FROM` clause.

This PR fixes the bug.

I did not attempt to correctly implement `.settings()` for queries other than `SELECT`s.

[settings-clause]: https://clickhouse.com/docs/en/sql-reference/statements/select#settings-in-select-query
[settings]: https://clickhouse.com/docs/en/operations/settings/settings

 ### Test Plan

Updated the unit test to be sensitive to the bug.